### PR TITLE
Fix bug where __hookbook_functions is clobbered:

### DIFF
--- a/hookbook.sh
+++ b/hookbook.sh
@@ -57,7 +57,7 @@ case "${__hookbook_shellname}" in
 
     ;;
   bash)
-    if declare -p __hookbook_functions >/dev/null 2>&1; then
+    if ! declare -p __hookbook_functions >/dev/null 2>&1; then
       __hookbook_functions=()
     fi
 


### PR DESCRIPTION
In bash, if hookbook is reloaded, rather than having no effect, `__hookbook_functions` is clobbered.

It's because I got a conditional backwards.

Yup.