### PR TITLE
Clean up testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: ruby
+rvm: 2.4.1
+git:
+  depth: 1
+before_install:
+  - sudo add-apt-repository -y ppa:hyperair/zsh-backports # Trusty's zsh deos not support pipefail
+  - sudo apt-get update
+  - sudo apt-get install -y zsh
+install: true
+script: ruby --disable-gems ./test

--- a/shell.rb
+++ b/shell.rb
@@ -11,8 +11,7 @@ class Shell
   end
 
   def send_commands(commands)
-    commands.lines.each { |command| send_command(command) }
-    self
+    commands.each { |command| send_command(command) }
   end
 
   def send_command(command)
@@ -21,11 +20,16 @@ class Shell
     end
     advance_to_prompt
     tw.join
-    self
   end
 
   def output
     @output.gsub("\r\n", "\n").lines
+  end
+
+  def output!
+    output
+  ensure
+    @output = ''
   end
 
   def close

--- a/test
+++ b/test
@@ -118,9 +118,9 @@ def run_test(expect, *argv, aliases: false)
   end
 end
 
-run_test(ZSH_EXPECT,  '/usr/local/bin/zsh', '--no-rcs', '--no-globalrcs')
+run_test(ZSH_EXPECT,  '/usr/local/bin/zsh', '--no-rcs', '--no-globalrcs', '-o', 'no_prompt_cr', '-o', 'no_zle')
 run_test(BASH_EXPECT, '/bin/bash', '--noprofile', '--norc')
 run_test(BASH_EXPECT, '/usr/local/bin/bash', '--noprofile', '--norc')
-run_test(ZSH_EXPECT,  '/usr/local/bin/zsh', '--no-rcs', '--no-globalrcs', aliases: true)
+run_test(ZSH_EXPECT,  '/usr/local/bin/zsh', '--no-rcs', '--no-globalrcs', '-o', 'no_prompt_cr', '-o', 'no_zle', aliases: true)
 run_test(BASH_EXPECT, '/bin/bash', '--noprofile', '--norc', aliases: true)
 run_test(BASH_EXPECT, '/usr/local/bin/bash', '--noprofile', '--norc', aliases: true)

--- a/test
+++ b/test
@@ -82,7 +82,7 @@ STRICT_EXPECT = <<EOF + PROMPT
 0
 EOF
 
-def run_test(expect, *argv, aliases: false)
+def run_test(version, expect, *argv, aliases: false)
   inputs = INPUTS
   inputs[0] = ALIASES if aliases
 
@@ -97,7 +97,7 @@ def run_test(expect, *argv, aliases: false)
 
   unescaped = (source_lines+setup_lines).select { |l| l.start_with?('unescaped ') }.uniq
 
-  title = "#{argv.first}#{' (escaping)' if aliases}"
+  title = "#{argv.first} #{version}#{' (escaping)' if aliases}"
   if unescaped.any?
     puts("NOT OK #{title}")
     puts(unescaped)
@@ -116,11 +116,12 @@ def run_test(expect, *argv, aliases: false)
   else
     puts("OK #{title}")
   end
+  run_test(version, expect, *argv, aliases: true) unless aliases
 end
 
-run_test(ZSH_EXPECT,  '/usr/local/bin/zsh', '--no-rcs', '--no-globalrcs', '-o', 'no_prompt_cr', '-o', 'no_zle')
-run_test(BASH_EXPECT, '/bin/bash', '--noprofile', '--norc')
-run_test(BASH_EXPECT, '/usr/local/bin/bash', '--noprofile', '--norc')
-run_test(ZSH_EXPECT,  '/usr/local/bin/zsh', '--no-rcs', '--no-globalrcs', '-o', 'no_prompt_cr', '-o', 'no_zle', aliases: true)
-run_test(BASH_EXPECT, '/bin/bash', '--noprofile', '--norc', aliases: true)
-run_test(BASH_EXPECT, '/usr/local/bin/bash', '--noprofile', '--norc', aliases: true)
+Shell.available_versions('zsh').each do |version, path|
+  run_test(version, ZSH_EXPECT, path, '--no-rcs', '--no-globalrcs', '-o', 'no_prompt_cr', '-o', 'no_zle')
+end
+Shell.available_versions('bash').each do |version, path|
+  run_test(version, BASH_EXPECT, path, '--noprofile', '--norc')
+end

--- a/test
+++ b/test
@@ -38,9 +38,9 @@ INPUTS = [
   [
     '\\true',
     '\\echo ok',
-    '\\echo ok | wc -l',
+    '\\echo ok | tr -d k',
     '\\source hookbook.sh',
-    '\\echo ok | wc -l',
+    '\\echo ok | tr -d k',
   ],
 ]
 
@@ -56,10 +56,10 @@ precmd
 preexec
 ok
 precmd
-> \\echo ok | wc -l
+> \\echo ok | tr -d k
 preexec
 preexec
-       1
+o
 precmd
 > \\source hookbook.sh
 preexec
@@ -67,10 +67,10 @@ preexec
 preexec
 preexec
 precmd
-> \\echo ok | wc -l
+> \\echo ok | tr -d k
 preexec
 preexec
-       1
+o
 precmd
 EOF
 

--- a/test
+++ b/test
@@ -6,6 +6,7 @@
 # /usr/local/bin/zsh is installed
 
 require_relative 'shell'
+require 'timeout'
 
 REQUIRE_ESCAPES = %w(
   alias alloc bg bind bindkey break breaksw builtins case cd chdir command complete continue default dirs do done echo
@@ -117,6 +118,10 @@ def run_test(version, expect, *argv, aliases: false)
     puts("OK #{title}")
   end
   run_test(version, expect, *argv, aliases: true) unless aliases
+rescue Timeout::Error
+  puts outputs
+  puts sh.output
+  raise
 end
 
 Shell.available_versions('zsh').each do |version, path|

--- a/test
+++ b/test
@@ -16,27 +16,40 @@ REQUIRE_ESCAPES = %w(
   until wait where which while
 )
 
-INPUT = <<EOF
-: @SET_ALIASES@
-\\set -eo pipefail
-: @START_STRICT@
-\\source hookbook.sh
-\\echo $?
-: @END_STRICT@
-f() { \\echo $1; }
-hookbook_add_hook f
-hookbook_add_hook f
-: @BEGIN@
-\\echo ok
-\\echo ok | wc -l
-\\source hookbook.sh
-\\echo ok | wc -l
-: @DONE@
-EOF
+ALIASES = REQUIRE_ESCAPES.map do |builtin|
+  %(\\alias #{builtin}='\\echo "unescaped #{builtin}: $0:$LINENO"')
+end
+
+
+INPUTS = [
+  [],
+  [
+    '\\set -eo pipefail',
+  ],
+  [
+    '\\source hookbook.sh',
+    '\\echo $?',
+  ],
+  [
+    'f() { \\echo $1; }',
+    'hookbook_add_hook f',
+    'hookbook_add_hook f',
+  ],
+  [
+    '\\true',
+    '\\echo ok',
+    '\\echo ok | wc -l',
+    '\\source hookbook.sh',
+    '\\echo ok | wc -l',
+  ],
+]
+
+PROMPT = '> '
 
 # We call DEBUG/preexec a lot of times when we source hookbook.sh the second
 # time. I wonder if we can cut that down to one.
-BASH_EXPECT = <<EOF
+BASH_EXPECT = <<EOF + PROMPT
+\\true
 preexec
 precmd
 > \\echo ok
@@ -63,39 +76,26 @@ EOF
 
 ZSH_EXPECT = BASH_EXPECT.gsub(/(preexec\n)+/, "preexec\n")
 
-STRICT_EXPECT = <<EOF
-> \\source hookbook.sh
+STRICT_EXPECT = <<EOF + PROMPT
+\\source hookbook.sh
 > \\echo $?
 0
 EOF
 
-def between(array, before, after)
-  index = array.index(before)
-  return [] unless index
-  array = array[index+1..-1]
-  index = array.index(after)
-  return [] unless index
-  array[0...index]
-end
-
 def run_test(expect, *argv, aliases: false)
-  input = INPUT
+  inputs = INPUTS
+  inputs[0] = ALIASES if aliases
 
-  if aliases
-    set_aliases = REQUIRE_ESCAPES.map do |builtin|
-      %(\\alias #{builtin}='\\echo "unescaped #{builtin}: $0:$LINENO"'\n)
-    end.join
-    input = input.sub(': @SET_ALIASES@', set_aliases + ': @ALIASES@')
+  sh = Shell.new(*argv, prompt: PROMPT)
+  outputs = inputs.map do |commands|
+    sh.send_commands(commands)
+    sh.output!
   end
-  sh = Shell.new(*argv, prompt: '> ').send_commands(input)
-  lines = sh.output
   sh.close
 
-  sourcing_output_lines = between(lines, "> : @ALIASES@\n", "> : @BEGIN@\n")
-  output_lines = between(lines, "> : @BEGIN@\n", "> : @DONE@\n")
-  strict_lines = between(lines, "> : @START_STRICT@\n", "> : @END_STRICT@\n")
+  alias_lines, pipefail_lines, source_lines, setup_lines, output_lines = outputs
 
-  unescaped = sourcing_output_lines.select { |l| l.start_with?('unescaped ') }.uniq
+  unescaped = (source_lines+setup_lines).select { |l| l.start_with?('unescaped ') }.uniq
 
   title = "#{argv.first}#{' (escaping)' if aliases}"
   if unescaped.any?
@@ -107,10 +107,10 @@ def run_test(expect, *argv, aliases: false)
     puts("HAVE: #{output_lines.join.inspect}")
     puts("WANT: #{expect.inspect}")
     abort('test failure')
-  elsif strict_lines.join != STRICT_EXPECT
+  elsif source_lines.join != STRICT_EXPECT
     puts("NOT OK #{title}")
     puts("failed strict check")
-    puts("HAVE: #{strict_lines.join.inspect}")
+    puts("HAVE: #{source_lines.join.inspect}")
     puts("WANT: #{STRICT_EXPECT.inspect}")
     abort('test failure')
   else


### PR DESCRIPTION
commit 8e5713c2ae01f26e608350dfbf40f3a30860073c (HEAD -> test_improvements, origin/test_improvements)
Author: Lisa Ugray <lisa.ugray@shopify.com>
Date:   Sat Mar 16 01:43:01 2019 -0400

    Add travis

commit ee7db6ee85897a99a1e3e32057b8e33fde75f29e
Author: Lisa Ugray <lisa.ugray@shopify.com>
Date:   Sat Mar 16 01:02:54 2019 -0400

    Add timeout

    If we encounter an error that prevents getting back to a prompt, timeout
    and print output for debugging.

commit 82e2b39b571f0be6937b4ee8a23e77e92946c47c
Author: Lisa Ugray <lisa.ugray@shopify.com>
Date:   Sat Mar 16 00:13:09 2019 -0400

    Make tests more cross platform

    wc has padding to right align output that differs platform to platform.

commit c16cc3d7ca8305288c7961fedfebcda258aa16f3
Author: Lisa Ugray <lisa.ugray@shopify.com>
Date:   Fri Mar 15 23:51:47 2019 -0400

    Detect shells

    Detect all veersions of shells on PATH. Makes this more cross platform,
    and resilient to locations.

commit e32f8d6e704394f19833de95cfd9fb4c9b464582
Author: Lisa Ugray <lisa.ugray@shopify.com>
Date:   Fri Mar 15 23:39:53 2019 -0400

    Remove marker commands

    Remove commands used only as markers, and structure related input and
    output instead.

commit 4f2fca0656fe60079f8f013a28af1ff6a38061d3
Author: Lisa Ugray <lisa.ugray@shopify.com>
Date:   Fri Mar 15 22:54:01 2019 -0400

    Clean up zsh

    Invoke zsh with arguments that make the output sanitization
    unneccessary.