### PR TITLE
Use absolute path to stat

### DIFF
--- a/hookbook.sh
+++ b/hookbook.sh
@@ -73,11 +73,11 @@ __hookbook_call_each() {
   # we gain nothing from running it in these cases because we already attach
   # to PROMPT_COMMAND.
   [[ "$(uname -s)" == "Darwin" ]] && {
-    __dev_null_major="$(stat -f "%Hr" "/dev/null")"
-    __stat_stderr='stat -f "%Hr" /dev/fd/2'
+    __dev_null_major="$(/usr/bin/stat -f "%Hr" "/dev/null")"
+    __stat_stderr='/usr/bin/stat -f "%Hr" /dev/fd/2'
   } || {
-    __dev_null_major="$(stat -c "%t" /dev/null)"
-    __stat_stderr='stat -c "%t" "$(readlink -f "/dev/fd/2")"'
+    __dev_null_major="$(/usr/bin/stat -c "%t" /dev/null)"
+    __stat_stderr='/usr/bin/stat -c "%t" "$(readlink -f "/dev/fd/2")"'
   }
   \eval "__hookbook_debug_handler() {
     [[ \"\${BASH_COMMAND}\" == \"\${PROMPT_COMMAND}\" ]] && \\return


### PR DESCRIPTION
This prevents an issue where stat can be non-default, like when coreutils is linked via homebrew.
```
stat: cannot read file system information for '%Hr': No such file or directory
```

If so, stat will not behave as expected

Reported by @jduff